### PR TITLE
Fix: use wrapping_add since the carry should be silently ignored

### DIFF
--- a/src/execution/value.rs
+++ b/src/execution/value.rs
@@ -37,8 +37,8 @@ impl std::ops::Add for Value {
     type Output = Self;
     fn add(self, rhs: Self) -> Self::Output {
         match (self, rhs) {
-            (Value::I32(left), Value::I32(right)) => Value::I32(left + right),
-            (Value::I64(left), Value::I64(right)) => Value::I64(left + right),
+            (Value::I32(left), Value::I32(right)) => Value::I32(left.wrapping_add(right)),
+            (Value::I64(left), Value::I64(right)) => Value::I64(left.wrapping_add(right)),
             _ => panic!("type mismatch"),
         }
     }


### PR DESCRIPTION
ref:
  - spec: https://webassembly.github.io/spec/core/exec/numerics.html#xref-exec-numerics-op-iadd-mathrm-iadd-n-i-1-i-2
  - reference manual: https://github.com/sunfishcode/wasm-reference-manual/blob/master/WebAssembly.md#integer-add